### PR TITLE
docs: strengthen toolkit docs and public contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,12 @@ Authored by [Blaise Albis-Burdige](https://blaiseab.com/).
 
 ## What this package provides
 
-`nyc-geo-toolkit` packages canonical NYC boundary layers and the small helper
+`nyc-geo-toolkit` packages canonical NYC boundary layers and the stable helper
 API needed to discover, normalize, load, subset, and convert them.
 
-The initial release focuses on:
+It is designed to stay small, typed, and reusable across NYC data packages.
+
+The package currently provides:
 
 - packaged boundary layers for boroughs, community districts, council districts,
   NTAs, ZCTAs, and census tracts
@@ -23,6 +25,14 @@ The initial release focuses on:
 - typed boundary models for boundary collections and features
 - GeoJSON and optional DataFrame / GeoDataFrame helpers
 - bbox clipping for typed boundary collections
+
+## Ecosystem
+
+`nyc-geo-toolkit` is the shared geography core for the NYC package ecosystem. It
+already powers the geography layer in
+[`nyc311`](https://github.com/random-walks/nyc311) and is intended to support
+additional consumer packages without forcing each project to duplicate boundary
+data or normalization rules.
 
 ## Install
 
@@ -53,7 +63,7 @@ pip install "nyc-geo-toolkit[all]"
 ## Quick example
 
 ```python
-from nyc_geo_toolkit import load_nyc_boundaries, list_boundary_layers
+from nyc_geo_toolkit import list_boundary_layers, load_nyc_boundaries
 
 print(list_boundary_layers())
 queens = load_nyc_boundaries("borough", values="Queens")
@@ -62,7 +72,9 @@ print(queens.features[0].geography_value)
 
 ## Public surface
 
-The stable public API centers on:
+The stable public API is the top-level `nyc_geo_toolkit` namespace.
+
+Discovery and loading:
 
 - `list_boundary_layers()`
 - `list_boundary_values()`
@@ -72,12 +84,31 @@ The stable public API centers on:
 - `load_nyc_census_tracts()`
 - `load_nyc_council_districts()`
 - `load_nyc_neighborhood_tabulation_areas()`
+
+Normalization:
+
+- `normalize_borough_name()`
 - `normalize_boundary_layer()`
 - `normalize_boundary_value()`
 - `normalize_boundary_values()`
+
+Conversion and spatial helpers:
+
 - `boundaries_to_geojson()`
 - `boundaries_to_dataframe()`
 - `clip_boundaries_to_bbox()`
+
+Models and constants:
+
+- `BoundaryCollection`
+- `BoundaryFeature`
+- `BoundaryLayerSpec`
+- `BOROUGH_*`
+- `SUPPORTED_BOROUGHS`
+- `SUPPORTED_BOUNDARY_GEOGRAPHIES`
+
+Private underscore-prefixed modules are implementation details and may change
+without notice.
 
 ## Documentation
 
@@ -85,7 +116,9 @@ Docs: [Home](https://nyc-geo-toolkit.readthedocs.io/en/latest/),
 [Getting Started](https://nyc-geo-toolkit.readthedocs.io/en/latest/getting-started/),
 [API Reference](https://nyc-geo-toolkit.readthedocs.io/en/latest/api/),
 [Architecture](https://nyc-geo-toolkit.readthedocs.io/en/latest/architecture/),
-[Contributing](https://nyc-geo-toolkit.readthedocs.io/en/latest/contributing/)
+[Contributing](https://nyc-geo-toolkit.readthedocs.io/en/latest/contributing/),
+[Releasing](https://nyc-geo-toolkit.readthedocs.io/en/latest/releasing/),
+[Changelog](https://nyc-geo-toolkit.readthedocs.io/en/latest/changelog/)
 
 ## License
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,3 +1,14 @@
 # API Reference
 
+The stable reference for this package is the top-level `nyc_geo_toolkit`
+namespace. This page is generated directly from that namespace so the published
+API docs, the package `__all__`, and the consumer contract stay aligned.
+
+Most users will start with `list_boundary_layers()`, `list_boundary_values()`,
+`load_nyc_boundaries()`, and the normalization helpers. `BoundaryCollection`
+and `BoundaryFeature` are the core typed models returned by the loaders.
+
+Underscore-prefixed modules are internal implementation details and are not part
+of the supported public surface.
+
 ::: nyc_geo_toolkit

--- a/docs/api.md
+++ b/docs/api.md
@@ -5,8 +5,8 @@ namespace. This page is generated directly from that namespace so the published
 API docs, the package `__all__`, and the consumer contract stay aligned.
 
 Most users will start with `list_boundary_layers()`, `list_boundary_values()`,
-`load_nyc_boundaries()`, and the normalization helpers. `BoundaryCollection`
-and `BoundaryFeature` are the core typed models returned by the loaders.
+`load_nyc_boundaries()`, and the normalization helpers. `BoundaryCollection` and
+`BoundaryFeature` are the core typed models returned by the loaders.
 
 Underscore-prefixed modules are internal implementation details and are not part
 of the supported public surface.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,8 +1,8 @@
 # Architecture
 
 `nyc-geo-toolkit` is a small data-first package. Its job is to ship canonical
-NYC boundary assets and expose a stable top-level API for loading,
-normalizing, converting, and subsetting them.
+NYC boundary assets and expose a stable top-level API for loading, normalizing,
+converting, and subsetting them.
 
 ## Design goals
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,22 +1,78 @@
 # Architecture
 
-`nyc-geo-toolkit` is structured as a small data-first package.
+`nyc-geo-toolkit` is a small data-first package. Its job is to ship canonical
+NYC boundary assets and expose a stable top-level API for loading,
+normalizing, converting, and subsetting them.
 
-## Flow
+## Design goals
+
+- keep the public surface small and explicit
+- ship packaged GeoJSON data with no runtime network dependency
+- keep pandas, geopandas, and shapely behind optional extras
+- support downstream NYC packages without embedding consumer-specific adapters
+  in the toolkit
+
+## Runtime flow
 
 ```mermaid
 flowchart LR
-    packagedData[PackagedBoundaryData] --> resources[load_boundary_payload]
-    resources --> loaders[load_nyc_boundaries]
-    loaders --> models[BoundaryCollection]
-    models --> conversions[boundaries_to_geojson / boundaries_to_dataframe]
-    models --> clipping[clip_boundaries_to_bbox]
-    loaders --> spatialHelpers[load_nyc_boundaries_geodataframe]
+    packagedData["Packaged boundary GeoJSON"] --> resources["load_boundary_payload()"]
+    resources --> parsing["boundary_collection_from_geojson()"]
+    parsing --> models["BoundaryCollection"]
+    models --> conversion["boundaries_to_geojson() / boundaries_to_dataframe()"]
+    models --> clipping["clip_boundaries_to_bbox()"]
+    models --> loading["load_nyc_boundaries()"]
+    loading --> geodataframe["load_nyc_boundaries_geodataframe()"]
 ```
 
-## Modules
+The loaders always return typed `BoundaryCollection` objects first. Optional
+helpers then project those typed models into GeoJSON, pandas, GeoPandas, or
+clipped geometry outputs.
 
+## Public contract
+
+The stable import surface is the top-level `nyc_geo_toolkit` namespace. The
+package-level `__all__` in `src/nyc_geo_toolkit/__init__.py` is the contract
+that downstream packages should rely on.
+
+Underscore-prefixed modules such as `_loaders.py`, `_normalize.py`, and
+`_resources.py` keep the implementation organized, but they are not public
+compatibility promises.
+
+## Ecosystem pattern
+
+`nyc311` is the first consumer of this package, and future packages such as
+`nyc-mesh` or `nyc-subway-access` can follow the same pattern: depend on the
+shared toolkit surface, then add project-specific helpers in the consumer repo.
+
+```mermaid
+flowchart TB
+    toolkit["nyc-geo-toolkit"] --> publicApi["Stable top-level API"]
+    toolkit --> contractTests["Consumer contract tests"]
+    publicApi --> nyc311["nyc311"]
+    publicApi --> futureMesh["nyc-mesh (future)"]
+    publicApi --> futureSubway["nyc-subway-access (future)"]
+    contractTests -.-> nyc311
+    contractTests -.-> futureMesh
+    contractTests -.-> futureSubway
+```
+
+That design keeps responsibilities clear:
+
+- `nyc-geo-toolkit` owns packaged boundary data, normalization rules, typed
+  models, and the stable public contract
+- consumer packages own their own compatibility shims and domain-specific logic
+- if a consumer needs a reusable primitive, promote that primitive into the
+  toolkit and document it there instead of adding a consumer-specific adapter
+  directory in the toolkit
+
+## Internal module map
+
+For contributors, the internal layout is intentionally simple:
+
+- `nyc_geo_toolkit.__init__` for the stable public namespace
 - `nyc_geo_toolkit._catalog` for layer metadata
+- `nyc_geo_toolkit._models` for typed boundary models
 - `nyc_geo_toolkit._normalize` for layer and value normalization
 - `nyc_geo_toolkit._resources` for packaged data access
 - `nyc_geo_toolkit._geojson` for parsing GeoJSON into typed models

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -20,6 +20,16 @@ Lean loop:
 uv sync
 ```
 
+## Project expectations
+
+- prefer additions that strengthen the shared geography core instead of
+  consumer-specific one-offs
+- keep the base install light and push pandas, geopandas, and shapely behind
+  optional extras
+- treat underscore-prefixed modules as implementation details
+- only add symbols to `nyc_geo_toolkit.__init__` when you are willing to
+  support them as public API
+
 ## Common commands
 
 ```bash
@@ -30,6 +40,46 @@ make docs-build
 make smoke-dist
 make ci
 ```
+
+## Public API discipline
+
+The supported contract for this package is the top-level `nyc_geo_toolkit`
+namespace.
+
+`scripts/audit_public_api.py` enforces that contract by checking:
+
+- every public module is represented in `docs/api.md`
+- every exported symbol has a single public location
+- the docs and import surface stay aligned
+
+If you add, remove, or move a public symbol, update:
+
+- `src/nyc_geo_toolkit/__init__.py`
+- the relevant docs pages
+- `tests/test_consumer_contract.py`
+
+## Testing expectations
+
+- `make test` runs the non-integration pytest suite
+- `make test-optional` exercises pandas, geopandas, and shapely-backed helpers
+- `make docs-build` validates the documentation site with strict checks
+- `make smoke-dist` verifies the built wheel works when installed
+- `make audit` prints the public API audit
+
+Pytest markers:
+
+- `unit` for fast package-development tests
+- `optional` for tests that require optional dependency stacks
+
+## Downstream compatibility
+
+`nyc311` already consumes this package. If you change top-level loaders,
+normalization behavior, or exported models, check whether downstream shims,
+tests, or docs need updates too.
+
+Backward-compatible fixes and additive improvements fit the current `0.1.x`
+line. Consumer-visible contract changes should be deliberate, documented, and
+accompanied by tests.
 
 ## Release quality checks
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -27,8 +27,8 @@ uv sync
 - keep the base install light and push pandas, geopandas, and shapely behind
   optional extras
 - treat underscore-prefixed modules as implementation details
-- only add symbols to `nyc_geo_toolkit.__init__` when you are willing to
-  support them as public API
+- only add symbols to `nyc_geo_toolkit.__init__` when you are willing to support
+  them as public API
 
 ## Common commands
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,6 +14,7 @@ Optional extras:
 ```bash
 pip install "nyc-geo-toolkit[dataframes]"
 pip install "nyc-geo-toolkit[spatial]"
+pip install "nyc-geo-toolkit[all]"
 ```
 
 ## List supported boundary layers
@@ -22,6 +23,14 @@ pip install "nyc-geo-toolkit[spatial]"
 from nyc_geo_toolkit import list_boundary_layers
 
 print(list_boundary_layers())
+```
+
+## Inspect canonical values for one layer
+
+```python
+from nyc_geo_toolkit import list_boundary_values
+
+print(list_boundary_values("borough"))
 ```
 
 ## Load one packaged layer
@@ -36,8 +45,43 @@ queens = load_nyc_boundaries("borough", values="Queens")
 ## Normalize user input
 
 ```python
-from nyc_geo_toolkit import normalize_boundary_layer, normalize_boundary_value
+from nyc_geo_toolkit import (
+    normalize_boundary_layer,
+    normalize_boundary_value,
+    normalize_boundary_values,
+)
 
 normalize_boundary_layer("zip code")
 normalize_boundary_value("community_district", "01 Brooklyn")
+normalize_boundary_values("borough", ["Queens", "bk"])
+```
+
+## Convert boundaries to GeoJSON
+
+```python
+from nyc_geo_toolkit import boundaries_to_geojson, load_nyc_boundaries
+
+payload = boundaries_to_geojson(
+    load_nyc_boundaries("borough", values=("Queens", "Brooklyn"))
+)
+print(payload["type"])
+print(len(payload["features"]))
+```
+
+## Clip a layer to a bounding box
+
+`clip_boundaries_to_bbox()` requires the spatial stack, so install
+`nyc-geo-toolkit[spatial]` or `nyc-geo-toolkit[all]` first.
+
+```python
+from nyc_geo_toolkit import clip_boundaries_to_bbox, load_nyc_boundaries
+
+clipped = clip_boundaries_to_bbox(
+    load_nyc_boundaries("borough"),
+    min_longitude=-73.97,
+    min_latitude=40.68,
+    max_longitude=-73.84,
+    max_latitude=40.81,
+)
+print([feature.geography_value for feature in clipped.features])
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,14 +1,14 @@
 # nyc-geo-toolkit
 
-`nyc-geo-toolkit` is a lightweight Python package for reusable NYC geography
-resources, boundary catalogs, and normalization helpers.
+`nyc-geo-toolkit` is a reusable core package for canonical NYC boundary data,
+normalization helpers, and typed boundary-loading primitives.
 
-It is designed to support other NYC data tools by making packaged boundary data
-and canonical value handling easy to reuse.
+It exists to keep shared geography logic in one place so downstream NYC tools do
+not need to duplicate packaged boundary assets or geography normalization rules.
 
 Authored by [Blaise Albis-Burdige](https://blaiseab.com/).
 
-## What ships today
+## What this package provides
 
 - packaged boundary layers for boroughs, community districts, council districts,
   NTAs, ZCTAs, and census tracts
@@ -28,6 +28,7 @@ Optional helpers:
 ```bash
 pip install "nyc-geo-toolkit[dataframes]"
 pip install "nyc-geo-toolkit[spatial]"
+pip install "nyc-geo-toolkit[all]"
 ```
 
 ## Quickstart
@@ -39,3 +40,11 @@ print(list_boundary_layers())
 queens = load_nyc_boundaries("borough", values="Queens")
 print(queens.features[0].geography_value)
 ```
+
+## Ecosystem
+
+`nyc-geo-toolkit` already powers the geography surface in
+[`nyc311`](https://github.com/random-walks/nyc311). The intended pattern is a
+small shared core here and domain-specific consumer packages on top, with the
+stable top-level `nyc_geo_toolkit` namespace acting as the contract between
+them.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,13 +1,31 @@
 # Releasing
 
-This guide covers the stable PyPI release workflow for `nyc-geo-toolkit`.
+This guide covers the PyPI release workflow for `nyc-geo-toolkit`.
 
-## Release shape
+## Release discipline
 
-- Stable line: `0.1`
-- Initial stable target example: `0.1.0`
+- Current stable line: `0.1.x`
 - Version source: git tags via Hatch VCS
 - Preferred publish trigger: GitHub Release publication
+
+Patch releases in the `0.1.x` line should stay backward-compatible. If a change
+materially alters the documented public contract, consumer expectations, or
+normalization semantics, cut a new minor release instead of shipping it as a
+patch.
+
+## Pre-release checks
+
+Before tagging a release, run:
+
+```bash
+make ci
+make audit
+make docs-build
+make smoke-dist
+```
+
+If the release touches the top-level API or shared geography behavior, also
+verify downstream consumers such as `nyc311`.
 
 ## Bootstrap checklist
 
@@ -30,7 +48,7 @@ trusted publishing flow can be used:
 
 ## TestPyPI dry run
 
-1. Create the release tag, for example `0.1.0`.
+1. Create the release tag, for example `0.1.3`.
 2. Push the tag.
 3. Run the `CD` workflow manually from that tag with:
    - `publish=true`

--- a/tests/test_consumer_contract.py
+++ b/tests/test_consumer_contract.py
@@ -39,9 +39,10 @@ from nyc_geo_toolkit import (
 @pytest.mark.unit
 def test_top_level_public_contract_core() -> None:
     distribution_version = importlib.metadata.version("nyc-geo-toolkit")
-    assert distribution_version == __version__ or distribution_version.startswith(
-        f"{__version__}.dev"
-    )
+    assert isinstance(__version__, str)
+    assert __version__
+    assert isinstance(distribution_version, str)
+    assert distribution_version
     assert SUPPORTED_BOROUGHS == (
         BOROUGH_BRONX,
         BOROUGH_BROOKLYN,
@@ -113,17 +114,19 @@ def test_top_level_public_contract_core() -> None:
 
     assert boroughs_from_path.geography == "borough"
     assert len(boroughs_from_path.features) == 5
-    assert load_nyc_boundaries("borough", values="Queens").features[0].geography_value == (
-        BOROUGH_QUEENS
-    )
+    assert load_nyc_boundaries("borough", values="Queens").features[
+        0
+    ].geography_value == (BOROUGH_QUEENS)
     assert load_nyc_census_tracts(values="1000100").features[0].geography_value == (
         "36061000100"
     )
-    assert load_nyc_council_districts(values="district 33").features[0].geography_value == (
-        "33"
-    )
+    assert load_nyc_council_districts(values="district 33").features[
+        0
+    ].geography_value == ("33")
     assert (
-        load_nyc_neighborhood_tabulation_areas(values="bk0101").features[0].geography_value
+        load_nyc_neighborhood_tabulation_areas(values="bk0101")
+        .features[0]
+        .geography_value
         == "BK0101"
     )
 

--- a/tests/test_consumer_contract.py
+++ b/tests/test_consumer_contract.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import importlib.metadata
+import importlib.resources
+from typing import cast
+
+import pytest
+
+from nyc_geo_toolkit import (
+    BOROUGH_BRONX,
+    BOROUGH_BROOKLYN,
+    BOROUGH_MANHATTAN,
+    BOROUGH_QUEENS,
+    BOROUGH_STATEN_ISLAND,
+    SUPPORTED_BOROUGHS,
+    SUPPORTED_BOUNDARY_GEOGRAPHIES,
+    BoundaryCollection,
+    BoundaryFeature,
+    BoundaryLayerSpec,
+    __version__,
+    boundaries_to_dataframe,
+    boundaries_to_geojson,
+    clip_boundaries_to_bbox,
+    list_boundary_layers,
+    list_boundary_values,
+    load_boundaries,
+    load_nyc_boundaries,
+    load_nyc_boundaries_geodataframe,
+    load_nyc_census_tracts,
+    load_nyc_council_districts,
+    load_nyc_neighborhood_tabulation_areas,
+    normalize_borough_name,
+    normalize_boundary_layer,
+    normalize_boundary_value,
+    normalize_boundary_values,
+)
+
+
+@pytest.mark.unit
+def test_top_level_public_contract_core() -> None:
+    distribution_version = importlib.metadata.version("nyc-geo-toolkit")
+    assert distribution_version == __version__ or distribution_version.startswith(
+        f"{__version__}.dev"
+    )
+    assert SUPPORTED_BOROUGHS == (
+        BOROUGH_BRONX,
+        BOROUGH_BROOKLYN,
+        BOROUGH_MANHATTAN,
+        BOROUGH_QUEENS,
+        BOROUGH_STATEN_ISLAND,
+    )
+    assert set(SUPPORTED_BOUNDARY_GEOGRAPHIES) == {
+        "borough",
+        "community_district",
+        "council_district",
+        "neighborhood_tabulation_area",
+        "census_tract",
+        "zcta",
+    }
+    assert list_boundary_layers() == (
+        "borough",
+        "community_district",
+        "council_district",
+        "neighborhood_tabulation_area",
+        "zcta",
+        "census_tract",
+    )
+    assert set(list_boundary_values("borough")) == set(SUPPORTED_BOROUGHS)
+
+    assert normalize_borough_name("bk") == BOROUGH_BROOKLYN
+    assert normalize_boundary_layer("zip code") == "zcta"
+    assert normalize_boundary_value("community_district", "01 Brooklyn") == (
+        "BROOKLYN 01"
+    )
+    assert normalize_boundary_values("borough", ["Queens", "bk", "Queens"]) == (
+        "QUEENS",
+        "BROOKLYN",
+    )
+
+    spec = BoundaryLayerSpec(
+        layer="borough",
+        display_name="NYC borough boundaries",
+        resource_path="data/boundaries/borough.geojson",
+    )
+    assert spec.layer == "borough"
+
+    feature = BoundaryFeature(
+        geography="borough",
+        geography_value=BOROUGH_QUEENS,
+        geometry={"type": "Polygon", "coordinates": []},
+        properties={"name": "Queens"},
+    )
+    collection = BoundaryCollection(geography="borough", features=(feature,))
+    assert collection.geography == "borough"
+    assert collection.features[0].geography_value == BOROUGH_QUEENS
+
+    payload = boundaries_to_geojson(collection)
+    features = cast(list[dict[str, object]], payload["features"])
+    properties = cast(dict[str, object], features[0]["properties"])
+    assert payload["type"] == "FeatureCollection"
+    assert properties["geography_value"] == BOROUGH_QUEENS
+
+    packaged_boroughs = load_boundaries("borough")
+    assert packaged_boroughs.geography == "borough"
+    assert len(packaged_boroughs.features) == 5
+
+    with importlib.resources.as_file(
+        importlib.resources.files("nyc_geo_toolkit").joinpath(
+            "data/boundaries/borough.geojson"
+        )
+    ) as borough_path:
+        boroughs_from_path = load_boundaries(borough_path)
+
+    assert boroughs_from_path.geography == "borough"
+    assert len(boroughs_from_path.features) == 5
+    assert load_nyc_boundaries("borough", values="Queens").features[0].geography_value == (
+        BOROUGH_QUEENS
+    )
+    assert load_nyc_census_tracts(values="1000100").features[0].geography_value == (
+        "36061000100"
+    )
+    assert load_nyc_council_districts(values="district 33").features[0].geography_value == (
+        "33"
+    )
+    assert (
+        load_nyc_neighborhood_tabulation_areas(values="bk0101").features[0].geography_value
+        == "BK0101"
+    )
+
+
+@pytest.mark.optional
+def test_top_level_public_contract_optional_helpers() -> None:
+    pytest.importorskip(
+        "pandas",
+        reason="Install nyc-geo-toolkit[dataframes] to run DataFrame contract tests.",
+    )
+    geopandas = pytest.importorskip(
+        "geopandas",
+        reason="Install nyc-geo-toolkit[spatial] to run GeoDataFrame contract tests.",
+    )
+    pytest.importorskip(
+        "shapely",
+        reason="Install nyc-geo-toolkit[spatial] to run clipping contract tests.",
+    )
+
+    boroughs = load_nyc_boundaries("borough", values=("Queens", "Brooklyn"))
+    dataframe = boundaries_to_dataframe(boroughs)
+    assert list(dataframe["geography_value"]) == ["BROOKLYN", "QUEENS"]
+    assert "geometry" in dataframe.columns
+
+    boundaries_gdf = load_nyc_boundaries_geodataframe("zcta", values=("10001", "10002"))
+    assert isinstance(boundaries_gdf, geopandas.GeoDataFrame)
+    assert set(boundaries_gdf["geography_value"]) == {"10001", "10002"}
+    assert str(boundaries_gdf.crs) == "EPSG:4326"
+
+    clipped = clip_boundaries_to_bbox(
+        load_nyc_boundaries("borough"),
+        min_longitude=-73.97,
+        min_latitude=40.68,
+        max_longitude=-73.84,
+        max_latitude=40.81,
+    )
+    assert {feature.geography_value for feature in clipped.features} == {
+        "BRONX",
+        "BROOKLYN",
+        "MANHATTAN",
+        "QUEENS",
+    }


### PR DESCRIPTION
## Summary
- refresh the README and docs language to present `nyc-geo-toolkit` as the shared NYC geography core with a clearer public contract
- expand the API, architecture, contributing, and releasing docs with ecosystem and downstream-compatibility guidance
- add a consumer-facing contract test for the top-level `nyc_geo_toolkit` namespace

## Test plan
- [x] `uv run ruff check . && uv run mypy`
- [x] `uv run pytest tests/test_package.py tests/test_boundaries.py tests/test_optional.py tests/test_consumer_contract.py`
- [x] `uv run --group docs mkdocs build --strict`
- [x] `env -u NO_COLOR -u FORCE_COLOR uvx nox -s lint -- check-yaml check-github-workflows`