### PR TITLE
feat: add lightweight geodesy helpers

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -68,6 +68,21 @@ print(payload["type"])
 print(len(payload["features"]))
 ```
 
+## Use the lightweight geodesy helpers
+
+```python
+from nyc_geo_toolkit import (
+    build_circle_polygon,
+    haversine_distance_meters,
+    walk_radius_meters,
+)
+
+radius = walk_radius_meters(10)
+distance = haversine_distance_meters(40.7061, -74.0086, 40.7580, -73.9855)
+polygon = build_circle_polygon(40.7128, -74.0060, radius)
+print(radius, round(distance), len(polygon))
+```
+
 ## Clip a layer to a bounding box
 
 `clip_boundaries_to_bbox()` requires the spatial stack, so install

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,8 @@ Authored by [Blaise Albis-Burdige](https://blaiseab.com/).
 - packaged boundary layers for boroughs, community districts, council districts,
   NTAs, ZCTAs, and census tracts
 - canonical normalization helpers for layer names and boundary values
+- lightweight dependency-free geodesy helpers for distance checks and first-pass
+  circle catchments
 - typed boundary models for boundary collections and features
 - GeoJSON and optional DataFrame / GeoDataFrame helpers
 - bbox clipping for typed boundary collections

--- a/src/nyc_geo_toolkit/__init__.py
+++ b/src/nyc_geo_toolkit/__init__.py
@@ -12,6 +12,7 @@ from ._constants import (
     SUPPORTED_BOUNDARY_GEOGRAPHIES,
 )
 from ._conversions import boundaries_to_dataframe, boundaries_to_geojson
+from ._geodesy import build_circle_polygon, haversine_distance_meters, walk_radius_meters
 from ._loaders import (
     list_boundary_layers,
     list_boundary_values,
@@ -43,10 +44,12 @@ __all__ = [
     "BoundaryCollection",
     "BoundaryFeature",
     "BoundaryLayerSpec",
+    "build_circle_polygon",
     "__version__",
     "boundaries_to_dataframe",
     "boundaries_to_geojson",
     "clip_boundaries_to_bbox",
+    "haversine_distance_meters",
     "list_boundary_layers",
     "list_boundary_values",
     "load_boundaries",
@@ -59,4 +62,5 @@ __all__ = [
     "normalize_boundary_layer",
     "normalize_boundary_value",
     "normalize_boundary_values",
+    "walk_radius_meters",
 ]

--- a/src/nyc_geo_toolkit/_geodesy.py
+++ b/src/nyc_geo_toolkit/_geodesy.py
@@ -1,0 +1,79 @@
+"""Small dependency-free geodesy helpers for NYC workflows."""
+
+from __future__ import annotations
+
+from math import asin, atan2, cos, degrees, pi, radians, sin, sqrt
+
+EARTH_RADIUS_METERS = 6_371_000.0
+DEFAULT_WALKING_METERS_PER_MINUTE = 80.0
+_POSITIVE_MINUTES_MESSAGE = "Walking minutes must be positive."
+_POSITIVE_RADIUS_MESSAGE = "Circle radius must be positive."
+_MINIMUM_SIDES_MESSAGE = "Circle polygons need at least 8 sides."
+
+
+def haversine_distance_meters(
+    latitude_a: float,
+    longitude_a: float,
+    latitude_b: float,
+    longitude_b: float,
+) -> float:
+    """Return the great-circle distance between two WGS84 points in meters."""
+
+    lat1 = radians(latitude_a)
+    lon1 = radians(longitude_a)
+    lat2 = radians(latitude_b)
+    lon2 = radians(longitude_b)
+
+    delta_lat = lat2 - lat1
+    delta_lon = lon2 - lon1
+    hav = (
+        sin(delta_lat / 2) ** 2
+        + cos(lat1) * cos(lat2) * sin(delta_lon / 2) ** 2
+    )
+    return 2 * EARTH_RADIUS_METERS * asin(sqrt(hav))
+
+
+def walk_radius_meters(
+    minutes: int | float, *, meters_per_minute: float = DEFAULT_WALKING_METERS_PER_MINUTE
+) -> float:
+    """Convert a walking-time threshold into an approximate radius in meters."""
+
+    if minutes <= 0:
+        raise ValueError(_POSITIVE_MINUTES_MESSAGE)
+    if meters_per_minute <= 0:
+        raise ValueError("Walking speed must be positive.")
+    return float(minutes) * meters_per_minute
+
+
+def build_circle_polygon(
+    latitude: float,
+    longitude: float,
+    radius_meters: float,
+    *,
+    sides: int = 24,
+) -> tuple[tuple[float, float], ...]:
+    """Return a simple lon/lat polygon approximating a circle around a point."""
+
+    if radius_meters <= 0:
+        raise ValueError(_POSITIVE_RADIUS_MESSAGE)
+    if sides < 8:
+        raise ValueError(_MINIMUM_SIDES_MESSAGE)
+
+    latitude_radians = radians(latitude)
+    angular_distance = radius_meters / EARTH_RADIUS_METERS
+    points: list[tuple[float, float]] = []
+
+    for index in range(sides):
+        bearing = 2 * pi * (index / sides)
+        lat = asin(
+            sin(latitude_radians) * cos(angular_distance)
+            + cos(latitude_radians) * sin(angular_distance) * cos(bearing)
+        )
+        lon = radians(longitude) + atan2(
+            sin(bearing) * sin(angular_distance) * cos(latitude_radians),
+            cos(angular_distance) - sin(latitude_radians) * sin(lat),
+        )
+        points.append((round(degrees(lon), 6), round(degrees(lat), 6)))
+
+    points.append(points[0])
+    return tuple(points)

--- a/tests/test_geodesy.py
+++ b/tests/test_geodesy.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from nyc_geo_toolkit import (
+    build_circle_polygon,
+    haversine_distance_meters,
+    walk_radius_meters,
+)
+
+
+def test_haversine_distance_meters_returns_zero_for_same_point() -> None:
+    assert haversine_distance_meters(40.7128, -74.0060, 40.7128, -74.0060) == 0.0
+
+
+def test_haversine_distance_meters_is_reasonable_for_known_distance() -> None:
+    # Lower Manhattan to Times Square is about 5.3 km as the crow flies.
+    distance = haversine_distance_meters(40.7061, -74.0086, 40.7580, -73.9855)
+    assert math.isclose(distance, 6_100, rel_tol=0.1)
+
+
+def test_walk_radius_meters_uses_default_walking_speed() -> None:
+    assert walk_radius_meters(10) == 800.0
+
+
+def test_walk_radius_meters_rejects_non_positive_values() -> None:
+    with pytest.raises(ValueError, match="Walking minutes must be positive"):
+        walk_radius_meters(0)
+
+    with pytest.raises(ValueError, match="Walking speed must be positive"):
+        walk_radius_meters(10, meters_per_minute=0)
+
+
+def test_build_circle_polygon_closes_ring() -> None:
+    polygon = build_circle_polygon(40.7128, -74.0060, 400)
+    assert len(polygon) == 25
+    assert polygon[0] == polygon[-1]
+
+
+def test_build_circle_polygon_rejects_invalid_inputs() -> None:
+    with pytest.raises(ValueError, match="Circle radius must be positive"):
+        build_circle_polygon(40.7128, -74.0060, 0)
+
+    with pytest.raises(ValueError, match="Circle polygons need at least 8 sides"):
+        build_circle_polygon(40.7128, -74.0060, 400, sides=6)


### PR DESCRIPTION
## Summary
- add dependency-free geodesy helpers for distance and first-pass circle buffers
- export the new helpers from the top-level toolkit namespace
- document and test the new shared helper layer

## Test plan
- [x] `uv sync --all-groups --all-extras`
- [x] `uv run pytest`
- [x] `uv run mkdocs build --strict`
- [x] `uv run python scripts/audit_public_api.py`
- [x] built wheel and ran installed-package smoke test