### PR TITLE
docs: add geo-toolkit example projects

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 *.geojson
+*.geojson

--- a/README.md
+++ b/README.md
@@ -70,6 +70,13 @@ queens = load_nyc_boundaries("borough", values="Queens")
 print(queens.features[0].geography_value)
 ```
 
+## Examples
+
+The repo now also ships self-contained consumer examples under `examples/`:
+
+- `examples/boundary-quickstart/`
+- `examples/normalization-demo/`
+
 ## Public surface
 
 The stable public API is the top-level `nyc_geo_toolkit` namespace.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,9 @@
+# Examples
+
+`examples/` contains self-contained consumer projects for `nyc-geo-toolkit`.
+
+Start with:
+
+- `examples/boundary-quickstart/`
+- `examples/normalization-demo/`
+- `examples/example-template/`

--- a/examples/boundary-quickstart/.gitignore
+++ b/examples/boundary-quickstart/.gitignore
@@ -1,0 +1,5 @@
+.venv/
+__pycache__/
+*.py[cod]
+cache/
+artifacts/

--- a/examples/boundary-quickstart/README.md
+++ b/examples/boundary-quickstart/README.md
@@ -1,0 +1,3 @@
+# Boundary Quickstart
+
+This example loads a single borough boundary and exports it as GeoJSON.

--- a/examples/boundary-quickstart/main.py
+++ b/examples/boundary-quickstart/main.py
@@ -28,7 +28,9 @@ def main() -> None:
     queens = load_nyc_boundaries("borough", values="Queens")
     geojson_payload = boundaries_to_geojson(queens)
     geojson_path = artifact_path("queens-borough.geojson")
-    geojson_path.write_text(f"{json.dumps(geojson_payload, indent=2)}\n", encoding="utf-8")
+    geojson_path.write_text(
+        f"{json.dumps(geojson_payload, indent=2)}\n", encoding="utf-8"
+    )
 
     report = f"""# Boundary Quickstart Tearsheet
 

--- a/examples/boundary-quickstart/main.py
+++ b/examples/boundary-quickstart/main.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from nyc_geo_toolkit import (
+    boundaries_to_geojson,
+    list_boundary_layers,
+    load_nyc_boundaries,
+)
+
+ROOT = Path(__file__).resolve().parent
+ARTIFACTS_DIR = ROOT / "artifacts"
+REPORTS_DIR = ROOT / "reports"
+
+
+def artifact_path(filename: str) -> Path:
+    ARTIFACTS_DIR.mkdir(parents=True, exist_ok=True)
+    return ARTIFACTS_DIR / filename
+
+
+def report_path(filename: str) -> Path:
+    REPORTS_DIR.mkdir(parents=True, exist_ok=True)
+    return REPORTS_DIR / filename
+
+
+def main() -> None:
+    queens = load_nyc_boundaries("borough", values="Queens")
+    geojson_payload = boundaries_to_geojson(queens)
+    geojson_path = artifact_path("queens-borough.geojson")
+    geojson_path.write_text(f"{json.dumps(geojson_payload, indent=2)}\n", encoding="utf-8")
+
+    report = f"""# Boundary Quickstart Tearsheet
+
+## Summary
+
+- Available boundary layers: {len(list_boundary_layers())}
+- Loaded features: {len(queens.features)}
+- Geography value: {queens.features[0].geography_value}
+
+## Artifact
+
+- GeoJSON: `{geojson_path.name}`
+"""
+    tearsheet_path = report_path("boundary-quickstart-tearsheet.md")
+    tearsheet_path.write_text(report, encoding="utf-8")
+
+    print(f"Wrote {geojson_path}")
+    print(f"Wrote {tearsheet_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/boundary-quickstart/pyproject.toml
+++ b/examples/boundary-quickstart/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "nyc-geo-toolkit-boundary-quickstart"
+version = "0.0.0"
+description = "Boundary loading quickstart for nyc-geo-toolkit."
+requires-python = ">=3.10"
+dependencies = ["nyc-geo-toolkit"]
+
+[tool.uv.sources]
+nyc-geo-toolkit = { path = "../..", editable = true }

--- a/examples/boundary-quickstart/reports/boundary-quickstart-tearsheet.md
+++ b/examples/boundary-quickstart/reports/boundary-quickstart-tearsheet.md
@@ -1,0 +1,11 @@
+# Boundary Quickstart Tearsheet
+
+## Summary
+
+- Available boundary layers: 6
+- Loaded features: 1
+- Geography value: QUEENS
+
+## Artifact
+
+- GeoJSON: `queens-borough.geojson`

--- a/examples/boundary-quickstart/uv.lock
+++ b/examples/boundary-quickstart/uv.lock
@@ -1,0 +1,49 @@
+version = 1
+revision = 3
+requires-python = ">=3.10"
+
+[[package]]
+name = "nyc-geo-toolkit"
+source = { editable = "../../" }
+
+[package.metadata]
+requires-dist = [
+    { name = "geopandas", marker = "extra == 'all'", specifier = ">=1.1" },
+    { name = "geopandas", marker = "extra == 'spatial'", specifier = ">=1.1" },
+    { name = "pandas", marker = "extra == 'all'", specifier = ">=2.3.3" },
+    { name = "pandas", marker = "extra == 'dataframes'", specifier = ">=2.3.3" },
+    { name = "shapely", marker = "extra == 'all'", specifier = ">=2.1" },
+    { name = "shapely", marker = "extra == 'spatial'", specifier = ">=2.1" },
+]
+provides-extras = ["all", "dataframes", "spatial"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = ">=1.18" },
+    { name = "pylint", specifier = ">=3.3" },
+    { name = "pytest", specifier = ">=9" },
+    { name = "pytest-cov", specifier = ">=7" },
+    { name = "ruff", specifier = ">=0.12" },
+]
+docs = [
+    { name = "markdown", specifier = ">=3.9" },
+    { name = "mkdocs", specifier = ">=1.1.2" },
+    { name = "mkdocs-material", specifier = ">=9.1.19" },
+    { name = "mkdocstrings-python", specifier = ">=1.18.2" },
+    { name = "pyyaml", specifier = ">=6.0.1" },
+]
+test = [
+    { name = "pytest", specifier = ">=9" },
+    { name = "pytest-cov", specifier = ">=7" },
+]
+
+[[package]]
+name = "nyc-geo-toolkit-boundary-quickstart"
+version = "0.0.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "nyc-geo-toolkit" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "nyc-geo-toolkit", editable = "../../" }]

--- a/examples/example-template/.gitignore
+++ b/examples/example-template/.gitignore
@@ -1,0 +1,5 @@
+.venv/
+__pycache__/
+*.py[cod]
+cache/
+artifacts/

--- a/examples/example-template/README.md
+++ b/examples/example-template/README.md
@@ -1,0 +1,5 @@
+# Example Template
+
+Copy this folder to a new semantic slug, then replace the placeholders in
+`main.py`, `pyproject.toml`, and this README with the story for your new
+example.

--- a/examples/example-template/main.py
+++ b/examples/example-template/main.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+CACHE_DIR = ROOT / "cache"
+ARTIFACTS_DIR = ROOT / "artifacts"
+REPORTS_DIR = ROOT / "reports"
+
+
+def main() -> None:
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    ARTIFACTS_DIR.mkdir(parents=True, exist_ok=True)
+    REPORTS_DIR.mkdir(parents=True, exist_ok=True)
+    print("nyc-geo-toolkit Example Template")
+    print("This folder is a bootstrap template, not a finished example.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/example-template/pyproject.toml
+++ b/examples/example-template/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "nyc-geo-toolkit-example-template"
+version = "0.0.0"
+description = "Bootstrap template for self-contained nyc-geo-toolkit examples."
+requires-python = ">=3.10"
+dependencies = ["nyc-geo-toolkit"]
+
+[tool.uv.sources]
+nyc-geo-toolkit = { path = "../..", editable = true }

--- a/examples/normalization-demo/.gitignore
+++ b/examples/normalization-demo/.gitignore
@@ -1,0 +1,5 @@
+.venv/
+__pycache__/
+*.py[cod]
+cache/
+artifacts/

--- a/examples/normalization-demo/README.md
+++ b/examples/normalization-demo/README.md
@@ -1,0 +1,4 @@
+# Normalization Demo
+
+This example shows how `nyc-geo-toolkit` cleans up layer names and geography
+values before loading boundaries.

--- a/examples/normalization-demo/main.py
+++ b/examples/normalization-demo/main.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from nyc_geo_toolkit import normalize_boundary_layer, normalize_boundary_values
+
+ROOT = Path(__file__).resolve().parent
+ARTIFACTS_DIR = ROOT / "artifacts"
+REPORTS_DIR = ROOT / "reports"
+
+
+def artifact_path(filename: str) -> Path:
+    ARTIFACTS_DIR.mkdir(parents=True, exist_ok=True)
+    return ARTIFACTS_DIR / filename
+
+
+def report_path(filename: str) -> Path:
+    REPORTS_DIR.mkdir(parents=True, exist_ok=True)
+    return REPORTS_DIR / filename
+
+
+def main() -> None:
+    raw_layer = "Community Districts"
+    raw_values = ["bk 01", "mn 03", "queens 07"]
+    normalized_layer = normalize_boundary_layer(raw_layer)
+    normalized_values = normalize_boundary_values(normalized_layer, raw_values)
+
+    artifact = {
+        "raw_layer": raw_layer,
+        "normalized_layer": normalized_layer,
+        "raw_values": raw_values,
+        "normalized_values": normalized_values,
+    }
+    artifact_pathname = artifact_path("normalized-values.json")
+    artifact_pathname.write_text(f"{json.dumps(artifact, indent=2)}\n", encoding="utf-8")
+
+    report = f"""# Normalization Demo Tearsheet
+
+## Summary
+
+- Raw layer: `{raw_layer}`
+- Normalized layer: `{normalized_layer}`
+- Values normalized: {len(normalized_values)}
+
+## Artifact
+
+- JSON: `{artifact_pathname.name}`
+"""
+    tearsheet_path = report_path("normalization-demo-tearsheet.md")
+    tearsheet_path.write_text(report, encoding="utf-8")
+
+    print(f"Wrote {artifact_pathname}")
+    print(f"Wrote {tearsheet_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/normalization-demo/main.py
+++ b/examples/normalization-demo/main.py
@@ -33,7 +33,9 @@ def main() -> None:
         "normalized_values": normalized_values,
     }
     artifact_pathname = artifact_path("normalized-values.json")
-    artifact_pathname.write_text(f"{json.dumps(artifact, indent=2)}\n", encoding="utf-8")
+    artifact_pathname.write_text(
+        f"{json.dumps(artifact, indent=2)}\n", encoding="utf-8"
+    )
 
     report = f"""# Normalization Demo Tearsheet
 

--- a/examples/normalization-demo/pyproject.toml
+++ b/examples/normalization-demo/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "nyc-geo-toolkit-normalization-demo"
+version = "0.0.0"
+description = "Normalization demo for nyc-geo-toolkit."
+requires-python = ">=3.10"
+dependencies = ["nyc-geo-toolkit"]
+
+[tool.uv.sources]
+nyc-geo-toolkit = { path = "../..", editable = true }

--- a/examples/normalization-demo/reports/normalization-demo-tearsheet.md
+++ b/examples/normalization-demo/reports/normalization-demo-tearsheet.md
@@ -1,0 +1,11 @@
+# Normalization Demo Tearsheet
+
+## Summary
+
+- Raw layer: `Community Districts`
+- Normalized layer: `community_district`
+- Values normalized: 3
+
+## Artifact
+
+- JSON: `normalized-values.json`

--- a/examples/normalization-demo/uv.lock
+++ b/examples/normalization-demo/uv.lock
@@ -1,0 +1,49 @@
+version = 1
+revision = 3
+requires-python = ">=3.10"
+
+[[package]]
+name = "nyc-geo-toolkit"
+source = { editable = "../../" }
+
+[package.metadata]
+requires-dist = [
+    { name = "geopandas", marker = "extra == 'all'", specifier = ">=1.1" },
+    { name = "geopandas", marker = "extra == 'spatial'", specifier = ">=1.1" },
+    { name = "pandas", marker = "extra == 'all'", specifier = ">=2.3.3" },
+    { name = "pandas", marker = "extra == 'dataframes'", specifier = ">=2.3.3" },
+    { name = "shapely", marker = "extra == 'all'", specifier = ">=2.1" },
+    { name = "shapely", marker = "extra == 'spatial'", specifier = ">=2.1" },
+]
+provides-extras = ["all", "dataframes", "spatial"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = ">=1.18" },
+    { name = "pylint", specifier = ">=3.3" },
+    { name = "pytest", specifier = ">=9" },
+    { name = "pytest-cov", specifier = ">=7" },
+    { name = "ruff", specifier = ">=0.12" },
+]
+docs = [
+    { name = "markdown", specifier = ">=3.9" },
+    { name = "mkdocs", specifier = ">=1.1.2" },
+    { name = "mkdocs-material", specifier = ">=9.1.19" },
+    { name = "mkdocstrings-python", specifier = ">=1.18.2" },
+    { name = "pyyaml", specifier = ">=6.0.1" },
+]
+test = [
+    { name = "pytest", specifier = ">=9" },
+    { name = "pytest-cov", specifier = ">=7" },
+]
+
+[[package]]
+name = "nyc-geo-toolkit-normalization-demo"
+version = "0.0.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "nyc-geo-toolkit" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "nyc-geo-toolkit", editable = "../../" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,7 @@ ignore = ["EM", "PLR09", "PLR2004", "RUF022", "SIM103", "TC", "TRY", "FURB110"]
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["T20"]
 "noxfile.py" = ["EXE001", "T20"]
+"examples/**" = ["T20"]
 
 [tool.pylint]
 py-version = "3.10"


### PR DESCRIPTION
## Summary
- add repo-level boundary and normalization example projects to match the ecosystem example contract
- add `.prettierignore` and small README guidance updates so downstream repos have a clearer shared reference for boundary-driven selection

## Test plan
- [x] `uv run ruff check .`
- [x] `uv run mypy src tests`
- [x] `uv run pylint src tests`
- [x] `uv run pytest tests`
- [x] `uv run mkdocs build --strict`
- [x] `uv run python scripts/audit_public_api.py`
- [x] `uv build && uv run python scripts/smoke_installed_package.py`

Made with [Cursor](https://cursor.com)