### PR TITLE
fix: resolve CI failures and update docs for stable release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install install-dev test test-optional lint lint-fix format docs docs-build audit clean build smoke-dist ci ci-lint ci-build ci-docs ci-tests
+.PHONY: help install install-dev test test-optional lint lint-fix format check docs docs-build audit clean build smoke-dist ci ci-lint ci-build ci-docs ci-tests
 
 help:
 	@echo "Available targets:"
@@ -15,6 +15,7 @@ help:
 	@echo "  docs-build   Build the docs with strict checks"
 	@echo "  audit        Print the public API audit"
 	@echo "  clean        Remove local caches and build artifacts"
+	@echo "  check        Run the lightweight pre-push check (everything CI lints, without build/docs/smoke)"
 	@echo "  ci           Run the local GitHub-CI-equivalent job sequence with summary output"
 
 install:
@@ -79,8 +80,13 @@ ci-tests:
 	uv run --frozen pytest -m "not integration" -ra --cov \
 		--cov-report=xml --cov-report=term --durations=20
 
+check:
+	$(MAKE) ci-lint
+	$(MAKE) ci-tests
+
 format:
 	uv run ruff check --fix . && uv run ruff format .
+	env -u NO_COLOR -u FORCE_COLOR uvx nox -s lint -- prettier
 
 docs:
 	uv run mkdocs serve

--- a/README.md
+++ b/README.md
@@ -99,7 +99,19 @@ Normalization:
 - `normalize_boundary_value()`
 - `normalize_boundary_values()`
 
-Conversion and spatial helpers:
+Geodesy helpers:
+
+- `haversine_distance_meters()`
+- `walk_radius_meters()`
+- `build_circle_polygon()`
+
+Basemap and spatial helpers:
+
+- `add_osm_basemap()`
+- `to_web_mercator()`
+- `bbox_around()`
+
+Conversion helpers:
 
 - `boundaries_to_geojson()`
 - `boundaries_to_dataframe()`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 Security fixes are provided for:
 
-- the latest published PyPI release in the `0.2` line
+- the latest published PyPI release in the `0.1` line
 - the current `main` branch before the next public release
 
 Older tags, prerelease milestones, and abandoned branches may not receive

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,9 +2,15 @@
 
 ## 0.1.7
 
-- add optional map helpers `add_osm_basemap`, `to_web_mercator`, and `bbox_around`
-  (see `nyc_geo_toolkit._basemap`), exported from the top-level namespace
+- add optional map helpers `add_osm_basemap`, `to_web_mercator`, and
+  `bbox_around` (see `nyc_geo_toolkit._basemap`), exported from the top-level
+  namespace
 - declare `contextily` as part of the `spatial` / `all` optional dependency sets
+- add `DeprecationWarning` filter for the `pyproj` NumPy scalar-conversion
+  warning so basemap tests pass on Python 3.10
+- promote Development Status classifier from Beta to Production/Stable
+- update docs to reflect current public API surface including basemap and
+  geodesy helpers
 
 ## 0.1.2
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -33,13 +33,18 @@ uv sync
 ## Common commands
 
 ```bash
-make test
-make test-optional
-make lint
-make docs-build
-make smoke-dist
-make ci
+make test           # run the non-integration pytest suite
+make test-optional  # exercise optional-dependency-backed features
+make lint           # Ruff + mypy + public API audit (fast)
+make format         # apply Ruff and Prettier formatting fixes
+make check          # full pre-push check (lint + tests, matches CI)
+make docs-build     # build the docs with strict checks
+make smoke-dist     # build and smoke-test an installed wheel
+make ci             # full local CI-equivalent (lint + build + smoke + docs + tests)
 ```
+
+**Before pushing**, run `make check` to catch everything CI will catch.
+`make format` auto-fixes both Python (Ruff) and non-Python (Prettier) files.
 
 ## Public API discipline
 
@@ -86,8 +91,13 @@ accompanied by tests.
 Before opening a PR, run:
 
 ```bash
-make ci
-make audit
+make check
 make docs-build
 make smoke-dist
+```
+
+For a full CI-equivalent run (including docs and distribution build):
+
+```bash
+make ci
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -83,6 +83,30 @@ polygon = build_circle_polygon(40.7128, -74.0060, radius)
 print(radius, round(distance), len(polygon))
 ```
 
+## Use the optional basemap helpers
+
+These helpers require the `spatial` extra:
+`pip install "nyc-geo-toolkit[spatial]"`.
+
+```python
+from nyc_geo_toolkit import bbox_around, to_web_mercator
+
+# Get a WGS84 bounding box (500 m radius) around a point
+minx, miny, maxx, maxy = bbox_around((-73.98, 40.75), 500.0)
+print(minx, miny, maxx, maxy)
+```
+
+```python
+import geopandas as gpd
+from shapely.geometry import Point
+
+from nyc_geo_toolkit import to_web_mercator
+
+gdf = gpd.GeoDataFrame(geometry=[Point(-73.98, 40.75)], crs="EPSG:4326")
+wm = to_web_mercator(gdf)
+print(wm.crs)
+```
+
 ## Clip a layer to a bounding box
 
 `clip_boundaries_to_bbox()` requires the spatial stack, so install

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,6 +18,7 @@ Authored by [Blaise Albis-Burdige](https://blaiseab.com/).
 - typed boundary models for boundary collections and features
 - GeoJSON and optional DataFrame / GeoDataFrame helpers
 - bbox clipping for typed boundary collections
+- optional basemap helpers for Web Mercator reprojection and OSM tile overlays
 
 ## Install
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ keywords = [
   "geospatial",
 ]
 classifiers = [
-  "Development Status :: 4 - Beta",
+  "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
   "Intended Audience :: Science/Research",
   "License :: OSI Approved :: MIT License",
@@ -91,7 +91,10 @@ markers = [
   "unit: fast local tests for package development",
   "optional: tests that exercise optional dependency-backed features",
 ]
-filterwarnings = ["error"]
+filterwarnings = [
+    "error",
+    "ignore:Conversion of an array with ndim > 0 to a scalar:DeprecationWarning",
+]
 log_level = "INFO"
 testpaths = ["tests"]
 


### PR DESCRIPTION
Fix Python 3.10 test failures caused by a pyproj DeprecationWarning (NumPy scalar conversion) being promoted to error by strict filterwarnings. Reformat docs/changelog.md to satisfy Prettier prose-wrap. Promote Development Status classifier from Beta to Production/Stable, fix SECURITY.md version line reference, add missing basemap and geodesy helpers to README and docs, and add `make check` / Prettier-in-format targets to close the CI-vs-local lint gap.
