### PR TITLE
feat: add centroids_from_boundaries helper (closes #12)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -65,6 +65,7 @@ of the supported public surface.
 ::: nyc_geo_toolkit
     options:
       members:
+        - centroids_from_boundaries
         - clip_boundaries_to_bbox
         - add_osm_basemap
         - to_web_mercator

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.4.0
+
+- add `centroids_from_boundaries(boundaries, *, representative=False)` in
+    `nyc_geo_toolkit._ops`, exported from the top-level namespace. Takes a
+    polygon / multi-polygon `BoundaryCollection` and returns a `Point`
+    `BoundaryCollection` preserving `geography`, `vintage`,
+    `geography_value`, and `properties` on every feature. Round-trips
+    through `boundaries_to_geojson` / `boundaries_to_dataframe`. Pass
+    `representative=True` for `shapely.Geometry.representative_point`
+    (always inside the polygon, safer for non-convex shapes like CDs with
+    concave shorelines) instead of the geometric centroid. Unblocks
+    downstream spatial analyses that need point geometries — distance-band
+    spatial weights, Moran's *I* / LISA, nearest-neighbor joins, choropleth
+    label placement — and replaces the hash-placement workaround in the
+    `blaise-website` resolution-equity showcase. Closes
+    [#12](https://github.com/random-walks/nyc-geo-toolkit/issues/12).
+
 ## 0.3.0
 
 - add Claude Code infrastructure parity with the `random-walks` ecosystem:

--- a/src/nyc_geo_toolkit/__init__.py
+++ b/src/nyc_geo_toolkit/__init__.py
@@ -39,7 +39,7 @@ from ._normalize import (
     normalize_boundary_value,
     normalize_boundary_values,
 )
-from ._ops import clip_boundaries_to_bbox
+from ._ops import centroids_from_boundaries, clip_boundaries_to_bbox
 from ._version import version as __version__
 
 __all__ = [
@@ -60,6 +60,7 @@ __all__ = [
     "__version__",
     "boundaries_to_dataframe",
     "boundaries_to_geojson",
+    "centroids_from_boundaries",
     "clip_boundaries_to_bbox",
     "describe_layer",
     "haversine_distance_meters",

--- a/src/nyc_geo_toolkit/_ops.py
+++ b/src/nyc_geo_toolkit/_ops.py
@@ -17,6 +17,76 @@ def _require_shapely() -> Any:
         ) from exc
 
 
+def centroids_from_boundaries(
+    boundaries: BoundaryCollection,
+    *,
+    representative: bool = False,
+) -> BoundaryCollection:
+    """Compute per-feature centroids as a Point ``BoundaryCollection``.
+
+    For every polygon or multi-polygon feature in ``boundaries``, returns a
+    GeoJSON ``Point`` geometry at either the geometric centroid (default) or
+    the shapely ``representative_point`` (guaranteed to fall inside the
+    polygon, useful for non-convex shapes like community districts with
+    concave shorelines). Feature identity — ``geography``, ``geography_value``,
+    and ``properties`` — round-trips verbatim, so the returned collection
+    can be fed back through :func:`boundaries_to_geojson` or
+    :func:`boundaries_to_dataframe`.
+
+    Requires the ``spatial`` extra (``pip install nyc-geo-toolkit[spatial]``).
+
+    Args:
+        boundaries: A ``BoundaryCollection`` of polygon / multipolygon features.
+        representative: When ``True``, use ``shapely.Geometry.representative_point``
+            (always inside the polygon). When ``False`` (default), use the
+            geometric centroid, which may fall outside for non-convex shapes.
+
+    Returns:
+        A new ``BoundaryCollection`` where each feature's ``geometry`` is a
+        GeoJSON ``Point``. The collection's ``geography`` and ``vintage`` are
+        preserved.
+
+    Raises:
+        ImportError: If shapely is not installed.
+        ValueError: If ``boundaries`` is empty (enforced by
+            ``BoundaryCollection``'s own invariant) or contains a feature
+            whose geometry is empty after centroid projection.
+
+    Example:
+        >>> from nyc_geo_toolkit import (
+        ...     centroids_from_boundaries,
+        ...     load_nyc_boundaries,
+        ... )
+        >>> cds = load_nyc_boundaries("community_district")
+        >>> points = centroids_from_boundaries(cds)
+        >>> points.features[0].geometry["type"]
+        'Point'
+    """
+    shapely_geometry = _require_shapely()
+    point_features: list[BoundaryFeature] = []
+    for feature in boundaries.features:
+        geometry = shapely_geometry.shape(feature.geometry)
+        point = geometry.representative_point() if representative else geometry.centroid
+        if point.is_empty:
+            raise ValueError(
+                f"Centroid for feature {feature.geography_value!r} is empty; "
+                "the source geometry may be degenerate."
+            )
+        point_features.append(
+            BoundaryFeature(
+                geography=feature.geography,
+                geography_value=feature.geography_value,
+                geometry=shapely_geometry.mapping(point),
+                properties=dict(feature.properties),
+            )
+        )
+    return BoundaryCollection(
+        geography=boundaries.geography,
+        features=tuple(point_features),
+        vintage=boundaries.vintage,
+    )
+
+
 def clip_boundaries_to_bbox(
     boundaries: BoundaryCollection,
     *,

--- a/tests/test_optional.py
+++ b/tests/test_optional.py
@@ -4,6 +4,7 @@ import pytest
 
 from nyc_geo_toolkit import (
     boundaries_to_dataframe,
+    centroids_from_boundaries,
     clip_boundaries_to_bbox,
     load_nyc_boundaries,
     load_nyc_boundaries_geodataframe,
@@ -22,6 +23,8 @@ pytest.importorskip(
     reason="Install nyc-geo-toolkit[spatial] to run GeoDataFrame tests.",
 )
 pytestmark = pytest.mark.optional
+
+from shapely.geometry import shape  # type: ignore[import-untyped]  # noqa: E402
 
 
 def test_boundaries_to_dataframe_returns_rows() -> None:
@@ -53,3 +56,48 @@ def test_clip_boundaries_to_bbox_returns_only_intersecting_boundaries() -> None:
         "MANHATTAN",
         "QUEENS",
     }
+
+
+def test_centroids_from_boundaries_returns_point_geometries() -> None:
+    boroughs = load_nyc_boundaries("borough")
+    centroids = centroids_from_boundaries(boroughs)
+
+    # Preserves collection identity (same layer, same vintage, same feature set).
+    assert centroids.geography == boroughs.geography
+    assert centroids.vintage == boroughs.vintage
+    assert {f.geography_value for f in centroids.features} == {
+        f.geography_value for f in boroughs.features
+    }
+
+    # Every feature is a GeoJSON Point with WGS84 coordinates in the NYC bbox.
+    for feature in centroids.features:
+        assert feature.geometry["type"] == "Point"
+        lon, lat = feature.geometry["coordinates"]
+        assert -74.3 <= lon <= -73.6, f"{feature.geography_value} lon={lon}"
+        assert 40.45 <= lat <= 40.95, f"{feature.geography_value} lat={lat}"
+
+
+def test_centroids_from_boundaries_preserves_properties() -> None:
+    cds = load_nyc_boundaries("community_district")
+    centroids = centroids_from_boundaries(cds)
+    assert len(centroids.features) == len(cds.features)
+    for original, centroid in zip(cds.features, centroids.features, strict=True):
+        assert centroid.geography_value == original.geography_value
+        assert centroid.properties == original.properties
+
+
+def test_centroids_from_boundaries_representative_points_fall_inside() -> None:
+    """representative=True must produce a point inside the source polygon.
+
+    Default geometric centroids can fall outside for non-convex shapes
+    (e.g. community districts with concave shorelines); that's the whole
+    point of the representative_point flag.
+    """
+    cds = load_nyc_boundaries("community_district")
+    rep_centroids = centroids_from_boundaries(cds, representative=True)
+    for original, rep in zip(cds.features, rep_centroids.features, strict=True):
+        polygon = shape(original.geometry)
+        point = shape(rep.geometry)
+        assert polygon.covers(point), (
+            f"representative point for {original.geography_value!r} fell outside polygon"
+        )


### PR DESCRIPTION
Closes #12.

## Summary

Adds `centroids_from_boundaries(boundaries, *, representative=False)` under `nyc_geo_toolkit._ops`, exported from the top-level namespace. Takes a polygon / multi-polygon `BoundaryCollection` and returns a Point `BoundaryCollection` preserving `geography`, `vintage`, `geography_value`, and `properties` on every feature. Round-trips through `boundaries_to_geojson` / `boundaries_to_dataframe`.

Pass `representative=True` for `shapely.Geometry.representative_point` (always inside the polygon — safer for non-convex shapes like community districts with concave shorelines) instead of the geometric centroid.

Implements issue #12's preferred option (\"Option 1: General helper\"). Option 2 (`.centroids` property on `BoundaryCollection`) can come as a thin sugar layer later if there's demand; option 3 (per-layer loaders) is explicitly out of scope per the issue.

## Why

Downstream spatial analyses need point geometries — distance-band spatial weights, Moran's *I* / LISA, nearest-neighbor joins, choropleth label placement. Today consumers either pull in `shapely` directly and iterate the `BoundaryCollection` (boilerplate in every caller), or roll a placeholder — see `blaise-website / packages/python-showcase/showcase-resolution-equity` `AUDIT.md` §5:

> Community-board polygon centroids are not shipped in `nyc311` v1.0 nor in `nyc-geo-toolkit` 0.3.0's minimal export. Rather than add a shapefile dependency under this branch, notebook 04 places each CB at a deterministic hash-derived point inside its borough's bounding box. This is sufficient for distance-band sensitivity analysis … but it is **not** a defensible geometry for a published paper.

With this helper, that showcase drops ~30 lines of hash-placement code and the LISA HH/LL counts become geographically meaningful rather than methodological demo output.

## Public-API touches

- [x] `_ops.py` — new `centroids_from_boundaries` function (additive)
- [x] `__init__.py` — new `__all__` entry

- [x] Change is additive (new public function, no signature churn)

## Checklist

- [x] `make check` green locally (53 passed, up from 50)
- [x] `make ci-docs` clean (`mkdocs build --strict`)
- [x] CHANGELOG entry added to `docs/changelog.md` under `## 0.4.0`
- [x] Public-API audit passes — new symbol has Google-style docstring with Args/Returns/Raises/Example blocks + `__all__` entry + docs/api.md reference under "Spatial Helpers"
- [x] No new optional dep — reuses existing `shapely` via `_require_shapely()` guard already used by `clip_boundaries_to_bbox`

## Test plan

Three new tests under `tests/test_optional.py` (marked `optional`, gated on `shapely` import):

- `test_centroids_from_boundaries_returns_point_geometries` — 5 borough centroids, each with `type=Point` and coords inside the NYC bounding box (−74.3..−73.6 lon, 40.45..40.95 lat).
- `test_centroids_from_boundaries_preserves_properties` — per-feature `geography_value` and `properties` round-trip across all 71 community districts.
- `test_centroids_from_boundaries_representative_points_fall_inside` — with `representative=True`, every CD's point lies inside its source polygon (`Polygon.covers`).

## Release

Additive public API. Minor bump to `v0.4.0` per `.claude/skills/release-bump.md`. No downstream coordination needed — `nyc311` / `subway-access` keep working against `>=0.3.0,<0.4` until they decide to pick this up (they'd need to widen the pin to `<0.5` first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)