### PR TITLE
feat(examples): align showcase with jellycell v1.4.0 native tearsheets API

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.4.1
+
+- align `examples/boundary-explorer-tearsheet/` with jellycell
+    [v1.4.0](https://github.com/random-walks/jellycell/releases/tag/v1.4.0),
+    which ships a native `jellycell.tearsheets.findings` / `methodology` /
+    `audit` Python API. The showcase now calls `jellycell.tearsheets.findings`
+    directly (passing the DiD results dict in-memory) instead of going
+    through `factor_factory.jellycell.tearsheets.findings`, which was a
+    pre-1.4 shim that read `artifacts/did_results.json` from disk via a
+    project-layout convention. Output is cleaner (proper metric table,
+    no placeholder sections), the showcase no longer depends on
+    factor-factory's jellycell sub-module, and downstream examples
+    picking up this pattern get jellycell's contract guarantees on
+    header pinning and byte-stable regeneration.
+- bump `jellycell[server]` pin on that example from `>=1.3.5,<2` to
+    `>=1.4.0,<2`.
+
 ## 0.4.0
 
 - add `centroids_from_boundaries(boundaries, *, representative=False)` in

--- a/examples/boundary-explorer-tearsheet/README.md
+++ b/examples/boundary-explorer-tearsheet/README.md
@@ -14,7 +14,8 @@ The three packages compose:
   (`factor_factory.tidy.Panel`) plus DiD estimation
   (`factor_factory.engines.did.estimate`).
 - **jellycell** supplies the manuscript renderer
-  (`factor_factory.jellycell.tearsheets.findings`).
+  ([`jellycell.tearsheets.findings`](https://github.com/random-walks/jellycell/blob/main/src/jellycell/tearsheets/__init__.py),
+  native in jellycell v1.4.0+ — takes the results dict directly).
 
 ## What it does
 
@@ -28,7 +29,9 @@ The three packages compose:
 6. Saves `artifacts/did_results.json` and the synthetic records to
    `data/synthetic_cd_panel.json`.
 7. Renders `manuscripts/FINDINGS.md` via
-   `factor_factory.jellycell.tearsheets.findings(project=<dir>)`.
+   `jellycell.tearsheets.findings(results=<dict>, out_path=...)` —
+   passing the DiD records directly, no filesystem-walking "project
+   layout" convention. Requires jellycell v1.4.0+.
 
 ## Run
 

--- a/examples/boundary-explorer-tearsheet/main.py
+++ b/examples/boundary-explorer-tearsheet/main.py
@@ -6,7 +6,9 @@ The three moving pieces:
   scaffolding (community-district polygons + canonical identifiers).
 - `factor_factory.tidy.Panel` + `factor_factory.engines.did.estimate`
   handle the panel data structure and TWFE DiD estimation.
-- `factor_factory.jellycell.tearsheets.findings` renders the manuscript.
+- `jellycell.tearsheets.findings` renders the manuscript (jellycell
+  v1.4.0's native Python API — takes the results dict directly, no
+  filesystem-walking project convention).
 
 The outcome follows the canonical DiD data-generating process:
 ``y_it = alpha_i + gamma_t + beta * 1[treated_i and t >= onset] + eps_it`` — unit
@@ -26,8 +28,8 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 from factor_factory.engines.did import estimate
-from factor_factory.jellycell.tearsheets import findings
 from factor_factory.tidy import Panel, PanelMetadata, TreatmentEvent
+from jellycell.tearsheets import findings
 
 from nyc_geo_toolkit import load_nyc_boundaries
 
@@ -161,23 +163,58 @@ def save_synthetic_records(treated: list[str], control: list[str]) -> Path:
     return out
 
 
-def fit_and_save(panel: Panel) -> Path:
+def fit_and_save(panel: Panel) -> tuple[list[dict[str, object]], Path]:
+    """Fit TWFE and archive the results as JSON.
+
+    Returns (records, path) — records is the `DidResults.to_records()` list
+    that the jellycell tearsheet also consumes directly (no read-back from
+    disk required).
+    """
     results = estimate(panel, methods=("twfe",), outcome="outcome")
+    records = results.to_records()
     out = ARTIFACTS_DIR / "did_results.json"
     payload = {
-        "results": results.to_records(),
+        "results": records,
         "panel_summary": panel.summary(),
         "ground_truth_att": GROUND_TRUTH_ATT,
     }
     out.write_text(json.dumps(payload, indent=2, default=str) + "\n", encoding="utf-8")
-    return out
+    return records, out
 
 
-def render_tearsheet() -> Path:
+def _records_for_tearsheet(
+    records: list[dict[str, object]],
+) -> dict[str, dict[str, object]]:
+    """Shape factor-factory DiD records for jellycell.tearsheets.findings.
+
+    jellycell's findings() renderer takes ``{estimator: {metric: value, ...}}``
+    and produces one ``## <estimator>`` section per key, with a two-column
+    metric table. Drop fields that aren't scalar (cohort_atts, diagnostics)
+    to keep the manuscript readable.
+    """
+    scalar_fields = ("att", "se", "ci_95_lower", "ci_95_upper", "p_value", "n")
+    return {
+        str(record["method"]): {k: record[k] for k in scalar_fields if k in record}
+        | {"ground_truth_att": GROUND_TRUTH_ATT}
+        for record in records
+    }
+
+
+def render_tearsheet(records: list[dict[str, object]]) -> Path:
+    """Render FINDINGS.md via jellycell v1.4.0's native tearsheets API."""
     return findings(
-        project=str(ROOT),
-        output_path=MANUSCRIPTS_DIR / "FINDINGS.md",
-        overwrite=True,
+        results=_records_for_tearsheet(records),
+        out_path=MANUSCRIPTS_DIR / "FINDINGS.md",
+        project="boundary-explorer-tearsheet",
+        title="Boundary Explorer Tearsheet — Findings",
+        subtitle=(
+            "Synthetic community-district DiD smoke test. "
+            "TWFE should recover the 4.0-unit ground-truth ATT within ~1 SE."
+        ),
+        template_overrides={
+            "author": "nyc-geo-toolkit",
+            "author_url": "https://github.com/random-walks/nyc-geo-toolkit",
+        },
     )
 
 
@@ -194,18 +231,17 @@ def main() -> None:
     panel = build_panel(treated, control)
     print(f"Built panel: {panel!r}")
 
-    results_path = fit_and_save(panel)
+    records, results_path = fit_and_save(panel)
     print(f"Wrote DiD results → {results_path.relative_to(ROOT)}")
 
-    payload = json.loads(results_path.read_text(encoding="utf-8"))
-    result = payload["results"][0]
-    err_ses = abs(result["att"] - GROUND_TRUTH_ATT) / result["se"]
+    result = records[0]
+    err_ses = abs(float(result["att"]) - GROUND_TRUTH_ATT) / float(result["se"])
     print(
         f"Recovered ATT={result['att']:.3f} (SE={result['se']:.3f}) "
         f"vs truth={GROUND_TRUTH_ATT} → {err_ses:.2f} SE"
     )
 
-    tearsheet_path = render_tearsheet()
+    tearsheet_path = render_tearsheet(records)
     print(f"Rendered tearsheet → {tearsheet_path.relative_to(ROOT)}")
 
 

--- a/examples/boundary-explorer-tearsheet/pyproject.toml
+++ b/examples/boundary-explorer-tearsheet/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.12"
 dependencies = [
     "nyc-geo-toolkit[spatial]",
     "factor-factory[did]>=1.0.2,<2",
-    "jellycell[server]>=1.3.5,<2",
+    "jellycell[server]>=1.4.0,<2",
 ]
 
 [tool.uv.sources]


### PR DESCRIPTION
Jellycell shipped [**v1.4.0**](https://github.com/random-walks/jellycell/releases/tag/v1.4.0) today with a native `jellycell.tearsheets` Python API (closes upstream [#24](https://github.com/random-walks/jellycell/issues/24)), plus all six of the J1–J6 issues I filed earlier this week. Align the showcase example with the new canonical call site before the next cut.

## What changed

### Before (pre-1.4 shim)

```python
from factor_factory.jellycell.tearsheets import findings

def render_tearsheet() -> Path:
    return findings(
        project=str(ROOT),
        output_path=MANUSCRIPTS_DIR / "FINDINGS.md",
        overwrite=True,
    )
```

The showcase wrote `artifacts/did_results.json` on disk, then called factor-factory's wrapper which walked the project dir, parsed the JSON back out, and rendered via an internal template. Filesystem convention + placeholder sections in the output.

### After (jellycell v1.4.0 native)

```python
from jellycell.tearsheets import findings

def render_tearsheet(records: list[dict[str, object]]) -> Path:
    return findings(
        results=_records_for_tearsheet(records),
        out_path=MANUSCRIPTS_DIR / "FINDINGS.md",
        project="boundary-explorer-tearsheet",
        title="Boundary Explorer Tearsheet — Findings",
        subtitle="Synthetic community-district DiD smoke test. …",
        template_overrides={
            "author": "nyc-geo-toolkit",
            "author_url": "https://github.com/random-walks/nyc-geo-toolkit",
        },
    )
```

Results dict goes in, markdown path comes out. No implicit filesystem convention. Header is pinnable via `template_overrides` for byte-stable regeneration.

## Output improvement

The old tearsheet had a \"No headline artifacts found in \`artifacts/\`…\" placeholder block because factor-factory's template expected a richer artifact set. The new one is a clean metric table:

```markdown
# Boundary Explorer Tearsheet — Findings

Synthetic community-district DiD smoke test. TWFE should recover the 4.0-unit ground-truth ATT within ~1 SE.

*Project: **boundary-explorer-tearsheet** · Author: [nyc-geo-toolkit](…) · April 2026 · jellycell 1.4.0*

---

## twfe

| Metric | Value |
| --- | --- |
| \`att\` | \`4.074\` |
| \`se\` | \`0.1503\` |
| \`ci_95_lower\` | \`3.779\` |
| \`ci_95_upper\` | \`4.369\` |
| \`p_value\` | \`0\` |
| \`n\` | \`720\` |
| \`ground_truth_att\` | \`4\` |
```

## Dependency bump

Example's `pyproject.toml` pin:

- `jellycell[server]>=1.3.5,<2` → `jellycell[server]>=1.4.0,<2`

factor-factory[did] stays pinned at `>=1.0.2,<2`. The showcase still uses factor-factory for the Panel + DiD fit — it just stops using factor-factory's jellycell sub-module, which is now redundant with jellycell's native API.

## Public-API touches

- [x] None of the above — example-only change, package surface unchanged.

## Checklist

- [x] `make check` green locally (53 passed)
- [x] `make ci-docs` clean (`mkdocs build --strict`)
- [x] CHANGELOG entry under `## 0.4.1`
- [x] Example runs end-to-end: ATT=4.074 (SE=0.150) vs truth 4.0 → 0.49 SE
- [x] Example README updated with the new API reference

## Release shape

Patch bump `0.4.0 → 0.4.1`. Example + dep alignment, no public surface change. Downstream pins unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)