### PR TITLE
docs(skill): sibling-relative consumer paths in downstream-compat

### DIFF
--- a/.claude/skills/downstream-compat.md
+++ b/.claude/skills/downstream-compat.md
@@ -58,8 +58,9 @@ Before merging any change to the files above, answer these:
 
 ## When in doubt
 
-- Grep the consumer repos if they're checked out locally:
-  `grep -r "from nyc_geo_toolkit" ~/Desktop/blaise-oss/nyc311 ~/Desktop/blaise-oss/subway-access`.
+- Grep the consumer repos if they're checked out locally — in the
+  blaise-dev-workspace layout they're siblings of this repo:
+  `grep -r "from nyc_geo_toolkit" ../nyc311 ../subway-access` (from this repo's root).
 - Or skim their `pyproject.toml` pin: `grep "nyc-geo-toolkit" */pyproject.toml`.
 - If you can't tell, default to **minor** bump and mention the change in the
   CHANGELOG under a `### Changed` subhead. The downstream maintainer will either


### PR DESCRIPTION
The repo now lives inside the `blaise-dev-workspace` meta-repo (`repos/nyc-geo-toolkit`), so the hardcoded `~/Desktop/blaise-oss/{nyc311,subway-access}` grep paths in the downstream-compat skill went stale. Switched to sibling-relative `../nyc311 ../subway-access`, which is robust to any future workspace relocation.

Doc-only change; no code or data touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)